### PR TITLE
Fix GFF/GTF column naming, closes #16

### DIFF
--- a/addon.c
+++ b/addon.c
@@ -12,7 +12,7 @@ static const char *col_defs[][15] = { /* FIXME: this is convenient, but not memo
 	{"bed", "chrom", "start", "end", "name", "score", "strand", "thickstart", "thickend", "rgb", "blockcount", "blocksizes", "blockstarts", NULL},
 	{"sam", "qname", "flag", "rname", "pos", "mapq", "cigar", "rnext", "pnext", "tlen", "seq", "qual", NULL},
 	{"vcf", "chrom", "pos", "id", "ref", "alt", "qual", "filter", "info", NULL},
-	{"gff", "seqname", "source", "feature", "start", "end", "score", "filter", "strand", "group", "attribute", NULL},
+	{"gff", "seqname", "source", "feature", "start", "end", "score", "strand", "frame", "attribute", NULL},
 	{"fastx", "name", "seq", "qual", "comment", NULL},
 	{NULL}
 };


### PR DESCRIPTION
c.f. the following on [bioinfo.se](https://bioinformatics.stackexchange.com/questions/661/what-kind-of-gff-format-does-bioawk-parse/665#665) and #16. This fixes #16 and standardizes the column names a bit.