### PR TITLE
Add arithmetic meanqual

### DIFF
--- a/addon.c
+++ b/addon.c
@@ -230,6 +230,18 @@ Cell *bio_func(int f, Cell *x, Node **a)
 				if (buf[i] - 33 >= thres) ++cnt;
 			setfval(y, (Awkfloat)cnt);
 		}
+	} else if (f == BIO_FARITHMEANQUAL) {
+		char *buf;
+		int i, l = 0;
+        double total_qual = 0.0;
+		buf = getsval(x);
+        /*printf("%s \n", buf);*/
+		l = strlen(buf);
+		if (l) { /* don't try for empty strings */
+			for (i = 0; i < l; ++i)
+				total_qual += pow(10, -((double)(buf[i] - 33) / 10) );
+			setfval(y, (Awkfloat)(-10 * log10(total_qual / l)) );
+		}
 	} /* else: never happens */
 	return y;
 }

--- a/addon.c
+++ b/addon.c
@@ -233,14 +233,14 @@ Cell *bio_func(int f, Cell *x, Node **a)
 	} else if (f == BIO_FARITHMEANQUAL) {
 		char *buf;
 		int i, l = 0;
-        double total_qual = 0.0;
+		double total_qual = 0.0;
 		buf = getsval(x);
-        /*printf("%s \n", buf);*/
 		l = strlen(buf);
 		if (l) { /* don't try for empty strings */
-			for (i = 0; i < l; ++i)
+			for (i = 0; i < l; ++i) /*convert Q-score to e-rate*/
 				total_qual += pow(10, -((double)(buf[i] - 33) / 10) );
-			setfval(y, (Awkfloat)(-10 * log10(total_qual / l)) );
+			/* mean of e-rate -> Q-score */
+			setfval(y, (Awkfloat)(-10 * log10(total_qual / l)) ); 
 		}
 	} /* else: never happens */
 	return y;

--- a/addon.h
+++ b/addon.h
@@ -41,6 +41,8 @@ int bio_getrec(char **pbuf, int *psize, int isrecord);
 #define BIO_FMEANQUAL 204
 #define BIO_FQUALCOUNT 205
 #define BIO_FTRIMQ    206
+#define BIO_FARITHMEANQUAL 207
+
 
 
 struct Cell;

--- a/lex.c
+++ b/lex.c
@@ -48,6 +48,7 @@ Keyword keywords[] ={	/* keep sorted: binary searched */
 	{ "END",	XEND,		XEND },
 	{ "NF",		VARNF,		VARNF },
 	{ "and",	BIO_FAND,	BLTIN },
+	{ "arithmeanqual",	BIO_FARITHMEANQUAL,		BLTIN },
 	{ "atan2",	FATAN,		BLTIN },
 	{ "break",	BREAK,		BREAK },
 	{ "close",	CLOSE,		CLOSE },


### PR DESCRIPTION
I added a function that calculates the arithmetic mean of the quality scores, rather than the geometric mean as `meanqual` currently does.

For motivation, please see [this blog post](https://gigabaseorgigabyte.wordpress.com/2017/06/26/averaging-basecall-quality-scores-the-right-way/). Using the geometric mean of Q-scores inflates the estimation of the quality of the scores.

The new `bioawk` method is called `arithmeanqual` and can be used in the following fashion:

`bioawk -c fastx '{print arithmeanqual($qual)}' mydata.fastq`

Thanks!