### PR TITLE
Avoid segfault on empty fastx file

### DIFF
--- a/addon.c
+++ b/addon.c
@@ -335,7 +335,9 @@ getrec_start:
 			}
 		}
 		adjbuf(&buf, &bufsize, g_str.l + 1, recsize, 0, "bio_getrec");
-		memcpy(buf, g_str.s, g_str.l + 1);
+		if (g_str.s) {
+			memcpy(buf, g_str.s, g_str.l + 1);
+		}
 		if (c >= 0) {	/* normal record */
 			if (isrecord) {
 				if (freeable(fldtab[0]))


### PR DESCRIPTION
Resolves https://github.com/lh3/bioawk/issues/37